### PR TITLE
Setup CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  max_report_age: off
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.gradle/configuration-cache
-          key: ${{ runner.os }}-gradle-conf-cache
+          key: ${{ runner.os }}-gradle-conf-cache-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-conf-cache
+            ${{ runner.os }}-gradle-conf-cache-
       - uses: burrunan/gradle-cache-action@v1
         name: Gradle build with caches caching
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cache gradle configuration
         uses: actions/cache@v2
         with:
-          path: ~/.gradle/configuration-cache
+          path: .gradle/configuration-cache
           key: ${{ runner.os }}-gradle-conf-cache-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-conf-cache-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,44 @@
+name: Build and test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build_and_test_with_code_coverage:
+    name: Build, test and upload code coverage
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v1.* is needed for correct codecov upload, see https://github.com/actions/checkout/issues/237 for details
+      - uses: actions/checkout@v1
+      # ensure that gradle wrapper files in repository are valid by checking checksums
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache gradle configuration
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/configuration-cache
+          key: ${{ runner.os }}-gradle-conf-cache
+          restore-keys: |
+            ${{ runner.os }}-gradle-conf-cache
+      - uses: burrunan/gradle-cache-action@v1
+        name: Gradle build with caches caching
+        with:
+          arguments: build
+          gradle-version: wrapper
+      - name: Upload test reports
+        if: ${{ failure() }}  # runs only if previous step has failed, the entire workflow will still be marked as failed
+        uses: actions/upload-artifact@v2
+        with:
+          name: gradle-test-report
+          path: '**/build/reports/'
+      - name: Code coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,4 +41,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           flags: unittests
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,48 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build release and create Github release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # ensure that gradle wrapper files in repository are valid by checking checksums
+      - uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache gradle configuration
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/configuration-cache
+          key: ${{ runner.os }}-gradle-conf-cache-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-conf-cache-
+      - uses: burrunan/gradle-cache-action@v1
+        name: Gradle build with caches caching
+        with:
+          arguments: :initiative-bot-discord:distZip
+          gradle-version: wrapper
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload jar file
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: initiative-bot-discord/build/distributions/*.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Cache gradle configuration
         uses: actions/cache@v2
         with:
-          path: ~/.gradle/configuration-cache
+          path: .gradle/configuration-cache
           key: ${{ runner.os }}-gradle-conf-cache-${{ hashFiles('**/*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-conf-cache-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.ajoberstar.reckon") version "0.13.0"
+    id("org.ajoberstar.reckon")
     id("com.github.ben-manes.versions") version "0.39.0"
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,8 +5,10 @@ plugins {
 repositories {
     mavenCentral()
     gradlePluginPortal()
+    maven("https://jitpack.io")
 }
 
 dependencies {
     implementation(kotlin("gradle-plugin", "1.5.30"))
+    implementation("com.github.ajoberstar.reckon:reckon-gradle:PR160-SNAPSHOT")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 group = "io.github.petertrr.initbot"
+org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
### What's done:
* Enable gradle build cache, gradle configuration cache
* Use compatible reckon plugin from jitpack
* Add build_and_test.yml, codecov.yml, create_release.yml

#### TODO:
* Gradle configuration cache doesn't work on CI, because gradle-cache-action updates `init.gradle` on new runs